### PR TITLE
Fix optional dependency imports to allow package import without them

### DIFF
--- a/src/lodum/bson.py
+++ b/src/lodum/bson.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: 2025-present Michael R. Bernstein <zopemaven@gmail.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-import bson
+try:
+    import bson
+except ImportError:
+    bson = None  # type: ignore
 from typing import Any, Iterator, Type, TypeVar
 
 from .core import Loader, BaseDumper, BaseLoader
@@ -14,6 +17,8 @@ T = TypeVar("T")
 
 def dumps(obj: Any) -> bytes:
     """Encodes a Python object to BSON bytes (dumps)."""
+    if bson is None:
+        raise ImportError("bson (pymongo) is required for BSON serialization. Install it with 'pip install lodum[bson]'.")
     dumper = BsonDumper()
     dumped_data = dump(obj, dumper)
     # BSON requires a dictionary at the root
@@ -24,6 +29,8 @@ def dumps(obj: Any) -> bytes:
 
 def loads(cls: Type[T], bson_bytes: bytes) -> T:
     """Decodes BSON bytes to a Python object (loads)."""
+    if bson is None:
+        raise ImportError("bson (pymongo) is required for BSON deserialization. Install it with 'pip install lodum[bson]'.")
     try:
         data = bson.decode(bson_bytes)
     except Exception as e:

--- a/src/lodum/cbor.py
+++ b/src/lodum/cbor.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: 2025-present Michael R. Bernstein <zopemaven@gmail.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-import cbor2
+try:
+    import cbor2
+except ImportError:
+    cbor2 = None  # type: ignore
 from typing import Any, Iterator, Type, TypeVar
 
 from .core import Loader, BaseDumper, BaseLoader
@@ -14,6 +17,8 @@ T = TypeVar("T")
 
 def dumps(obj: Any) -> bytes:
     """Encodes a Python object to CBOR bytes (dumps)."""
+    if cbor2 is None:
+        raise ImportError("cbor2 is required for CBOR serialization. Install it with 'pip install lodum[cbor]'.")
     dumper = CborDumper()
     dumped_data = dump(obj, dumper)
     return cbor2.dumps(dumped_data)
@@ -21,6 +26,8 @@ def dumps(obj: Any) -> bytes:
 
 def loads(cls: Type[T], cbor_bytes: bytes) -> T:
     """Decodes CBOR bytes to a Python object (loads)."""
+    if cbor2 is None:
+        raise ImportError("cbor2 is required for CBOR deserialization. Install it with 'pip install lodum[cbor]'.")
     try:
         data = cbor2.loads(cbor_bytes)
     except Exception as e:

--- a/src/lodum/internal.py
+++ b/src/lodum/internal.py
@@ -5,9 +5,20 @@ import uuid
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, get_origin, get_args, cast
-import numpy as np
-import pandas as pd
-import polars as pl
+try:
+    import numpy as np
+except ImportError:
+    np = None  # type: ignore
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None  # type: ignore
+
+try:
+    import polars as pl
+except ImportError:
+    pl = None  # type: ignore
 
 from .core import Loader, Dumper
 from .exception import DeserializationError, SerializationError
@@ -356,19 +367,19 @@ def _dump_decimal(obj: Decimal, d: Dumper) -> str:
 def _dump_path(obj: Path, d: Dumper) -> str:
     return d.dump_str(str(obj))
 
-def _dump_numpy_array(obj: np.ndarray, d: Dumper) -> Any:
+def _dump_numpy_array(obj: Any, d: Dumper) -> Any:
     return dump(obj.tolist(), d)
 
-def _dump_pandas_dataframe(obj: pd.DataFrame, d: Dumper) -> Any:
+def _dump_pandas_dataframe(obj: Any, d: Dumper) -> Any:
     return dump(obj.to_dict(orient="records"), d)
 
-def _dump_pandas_series(obj: pd.Series, d: Dumper) -> Any:
+def _dump_pandas_series(obj: Any, d: Dumper) -> Any:
     return dump(obj.to_dict(), d)
 
-def _dump_polars_dataframe(obj: pl.DataFrame, d: Dumper) -> Any:
+def _dump_polars_dataframe(obj: Any, d: Dumper) -> Any:
     return dump(obj.to_dict(), d)
 
-def _dump_polars_series(obj: pl.Series, d: Dumper) -> Any:
+def _dump_polars_series(obj: Any, d: Dumper) -> Any:
     return dump(obj.to_list(), d)
 
 DUMP_DISPATCH.update({
@@ -381,12 +392,16 @@ DUMP_DISPATCH.update({
     uuid.UUID: _dump_uuid,
     Decimal: _dump_decimal,
     Path: _dump_path,
-    np.ndarray: _dump_numpy_array,
-    pd.DataFrame: _dump_pandas_dataframe,
-    pd.Series: _dump_pandas_series,
-    pl.DataFrame: _dump_polars_dataframe,
-    pl.Series: _dump_polars_series,
 })
+
+if np is not None:
+    DUMP_DISPATCH[np.ndarray] = _dump_numpy_array
+if pd is not None:
+    DUMP_DISPATCH[pd.DataFrame] = _dump_pandas_dataframe
+    DUMP_DISPATCH[pd.Series] = _dump_pandas_series
+if pl is not None:
+    DUMP_DISPATCH[pl.DataFrame] = _dump_polars_dataframe
+    DUMP_DISPATCH[pl.Series] = _dump_polars_series
 
 def _load_primitive(cls: Type[T], loader: Loader, path: Optional[str] = None) -> T:
     try:
@@ -555,18 +570,28 @@ def _load_set(cls: Type[T], loader: Loader, path: Optional[str] = None) -> T:
         raise DeserializationError(msg, e.path if isinstance(e, DeserializationError) and e.path else path)
 
 def _load_numpy_array(cls: Type[T], loader: Loader, path: Optional[str] = None) -> T:
+    if np is None:
+        raise ImportError("numpy is required for numpy array deserialization")
     return cast(T, np.array(load(List, loader, path)))
 
 def _load_pandas_dataframe(cls: Type[T], loader: Loader, path: Optional[str] = None) -> T:
+    if pd is None:
+        raise ImportError("pandas is required for pandas DataFrame deserialization")
     return cast(T, pd.DataFrame.from_records(load(list, loader, path)))
 
 def _load_pandas_series(cls: Type[T], loader: Loader, path: Optional[str] = None) -> T:
+    if pd is None:
+        raise ImportError("pandas is required for pandas Series deserialization")
     return cast(T, pd.Series(load(dict, loader, path)))
 
 def _load_polars_dataframe(cls: Type[T], loader: Loader, path: Optional[str] = None) -> T:
+    if pl is None:
+        raise ImportError("polars is required for polars DataFrame deserialization")
     return cast(T, pl.DataFrame(load(dict, loader, path)))
 
 def _load_polars_series(cls: Type[T], loader: Loader, path: Optional[str] = None) -> T:
+    if pl is None:
+        raise ImportError("polars is required for polars Series deserialization")
     return cast(T, pl.Series(load(list, loader, path)))
 
 LOAD_DISPATCH.update({
@@ -580,9 +605,13 @@ LOAD_DISPATCH.update({
     Decimal: _load_decimal,
     Path: _load_path,
     Any: _load_any,
-    np.ndarray: _load_numpy_array,
-    pd.DataFrame: _load_pandas_dataframe,
-    pd.Series: _load_pandas_series,
-    pl.DataFrame: _load_polars_dataframe,
-    pl.Series: _load_polars_series,
 })
+
+if np is not None:
+    LOAD_DISPATCH[np.ndarray] = _load_numpy_array
+if pd is not None:
+    LOAD_DISPATCH[pd.DataFrame] = _load_pandas_dataframe
+    LOAD_DISPATCH[pd.Series] = _load_pandas_series
+if pl is not None:
+    LOAD_DISPATCH[pl.DataFrame] = _load_polars_dataframe
+    LOAD_DISPATCH[pl.Series] = _load_polars_series

--- a/src/lodum/msgpack.py
+++ b/src/lodum/msgpack.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: 2025-present Michael R. Bernstein <zopemaven@gmail.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-import msgpack
+try:
+    import msgpack
+except ImportError:
+    msgpack = None  # type: ignore
 from typing import Any, Iterator, Type, TypeVar
 
 from .core import Loader, BaseDumper, BaseLoader
@@ -14,6 +17,8 @@ T = TypeVar("T")
 
 def dumps(obj: Any) -> bytes:
     """Encodes a Python object to MsgPack bytes (dumps)."""
+    if msgpack is None:
+        raise ImportError("msgpack is required for MsgPack serialization. Install it with 'pip install lodum[msgpack]'.")
     dumper = MsgPackDumper()
     dumped_data = dump(obj, dumper)
     return msgpack.packb(dumped_data, use_bin_type=True)
@@ -21,6 +26,8 @@ def dumps(obj: Any) -> bytes:
 
 def loads(cls: Type[T], packed_bytes: bytes) -> T:
     """Decodes MsgPack bytes to a Python object (loads)."""
+    if msgpack is None:
+        raise ImportError("msgpack is required for MsgPack deserialization. Install it with 'pip install lodum[msgpack]'.")
     try:
         data = msgpack.unpackb(packed_bytes, raw=False)
     except Exception as e:

--- a/src/lodum/toml.py
+++ b/src/lodum/toml.py
@@ -4,8 +4,15 @@
 try:
     import tomllib
 except ImportError:
-    import tomli as tomllib  # type: ignore[no-redef, import-not-found]
-import tomli_w
+    try:
+        import tomli as tomllib  # type: ignore[no-redef, import-not-found]
+    except ImportError:
+        tomllib = None  # type: ignore
+
+try:
+    import tomli_w
+except ImportError:
+    tomli_w = None  # type: ignore
 from typing import Any, Iterator, Type, TypeVar
 
 from .core import Loader, BaseDumper, BaseLoader
@@ -18,6 +25,8 @@ T = TypeVar("T")
 
 def dumps(obj: Any) -> str:
     """Encodes a Python object to a TOML string (dumps)."""
+    if tomli_w is None:
+        raise ImportError("tomli-w is required for TOML serialization. Install it with 'pip install lodum[toml]'.")
     dumper = TomlDumper()
     dumped_data = dump(obj, dumper)
     return tomli_w.dumps(dumped_data)
@@ -25,6 +34,8 @@ def dumps(obj: Any) -> str:
 
 def loads(cls: Type[T], toml_string: str) -> T:
     """Decodes a TOML string to a Python object (loads)."""
+    if tomllib is None:
+        raise ImportError("tomllib (or tomli) is required for TOML deserialization. Install it with 'pip install lodum[toml]'.")
     try:
         data = tomllib.loads(toml_string)
     except tomllib.TOMLDecodeError as e:

--- a/src/lodum/yaml.py
+++ b/src/lodum/yaml.py
@@ -3,13 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 import io
 from typing import Any, Iterator, Type, TypeVar
-from ruamel.yaml import YAML
+try:
+    from ruamel.yaml import YAML
+    yaml_available = True
+except ImportError:
+    YAML = None  # type: ignore
+    yaml_available = False
 
 from .core import Loader, Dumper
 from .internal import dump, load
 
 T = TypeVar("T")
-yaml = YAML(typ='safe')
+if yaml_available:
+    yaml = YAML(typ='safe')
+else:
+    yaml = None
 
 # --- Public API ---
 
@@ -17,6 +25,9 @@ def dumps(obj: Any) -> str:
     """
     Encodes a Python object to a YAML string.
     """
+    if not yaml_available:
+        raise ImportError("ruamel.yaml is required for YAML serialization. Install it with 'pip install lodum[yaml]'.")
+
     dumper = YamlDumper()
     # The core `dump` logic is format-agnostic and can be reused.
     dumped_data = dump(obj, dumper)
@@ -29,6 +40,9 @@ def loads(cls: Type[T], yaml_string: str) -> T:
     """
     Decodes a YAML string to a Python object.
     """
+    if not yaml_available:
+        raise ImportError("ruamel.yaml is required for YAML deserialization. Install it with 'pip install lodum[yaml]'.")
+
     data = yaml.load(yaml_string)
     loader = YamlLoader(data)
     # The core `load` logic is format-agnostic and can be reused.


### PR DESCRIPTION
This change wraps optional third-party library imports (numpy, pandas, polars, ruamel.yaml, msgpack, tomli-w, cbor2, bson) in try-except blocks. It ensures that the `lodum` package can be imported even if these dependencies are missing, only raising descriptive ImportErrors when the missing functionality is explicitly used.

- Updated `internal.py` to handle numpy, pandas, and polars optionally.
- Updated format modules (`yaml.py`, `msgpack.py`, `toml.py`, `cbor.py`, `bson.py`) to handle their respective dependencies optionally.
- Updated internal handler type hints to `Any` to avoid runtime errors when dependencies are missing.
- Implemented conditional registration in dispatch tables.