### PR TITLE
Add __repr__ and __eq__ to Field class

### DIFF
--- a/src/lodum/field.py
+++ b/src/lodum/field.py
@@ -54,6 +54,43 @@ class Field:
             return self.default_factory()
         return self.default
 
+    def __repr__(self) -> str:
+        parts = []
+        if self.name:
+            parts.append(f"name={self.name!r}")
+        if self.type:
+            parts.append(f"type={self.type!r}")
+        if self.rename:
+            parts.append(f"rename={self.rename!r}")
+        if self.skip_serializing:
+            parts.append(f"skip_serializing={self.skip_serializing!r}")
+        if self.default is not _MISSING:
+            parts.append(f"default={self.default!r}")
+        if self.default_factory:
+            parts.append(f"default_factory={self.default_factory!r}")
+        if self.serializer:
+            parts.append(f"serializer={self.serializer!r}")
+        if self.deserializer:
+            parts.append(f"deserializer={self.deserializer!r}")
+        if self.validate:
+            parts.append(f"validate={self.validate!r}")
+        return f"Field({', '.join(parts)})"
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Field):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.type == other.type
+            and self.rename == other.rename
+            and self.skip_serializing == other.skip_serializing
+            and self.default == other.default
+            and self.default_factory == other.default_factory
+            and self.serializer == other.serializer
+            and self.deserializer == other.deserializer
+            and self.validate == other.validate
+        )
+
 
 def field(
     *,

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,0 +1,54 @@
+from lodum.field import Field, _MISSING, field
+import pytest
+
+def test_field_repr():
+    f = Field(rename="foo", skip_serializing=True)
+    f.name = "bar"
+    f.type = int
+    repr_str = repr(f)
+    assert "Field" in repr_str
+    assert "name='bar'" in repr_str
+    assert "type=<class 'int'>" in repr_str
+    assert "rename='foo'" in repr_str
+    assert "skip_serializing=True" in repr_str
+
+def test_field_eq():
+    f1 = Field(rename="foo")
+    f1.name = "bar"
+    f1.type = int
+
+    f2 = Field(rename="foo")
+    f2.name = "bar"
+    f2.type = int
+
+    assert f1 == f2
+
+    f3 = Field(rename="baz")
+    f3.name = "bar"
+    f3.type = int
+    assert f1 != f3
+
+    f4 = Field(rename="foo")
+    f4.name = "qux"
+    f4.type = int
+    assert f1 != f4
+
+def test_field_eq_with_defaults():
+    f1 = Field(default=10)
+    f2 = Field(default=10)
+    assert f1 == f2
+
+    f3 = Field(default=20)
+    assert f1 != f3
+
+def test_field_eq_with_factory():
+    def factory():
+        return []
+    f1 = Field(default_factory=factory)
+    f2 = Field(default_factory=factory)
+    assert f1 == f2
+
+    def factory2():
+        return []
+    f3 = Field(default_factory=factory2)
+    assert f1 != f3


### PR DESCRIPTION
This commit implements standard Python dunder methods for the Field class to improve debuggability and allow for value-based comparison of field metadata.

Changes:
- Added __repr__ to Field class in src/lodum/field.py
- Added __eq__ to Field class in src/lodum/field.py
- Added unit tests in tests/test_field.py