### PR TITLE
Standardize tool configurations in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,40 @@ dependencies = [
 
 [tool.hatch.envs.default.scripts]
 test = "pytest"
+
+[tool.ruff]
+target-version = "py39"
+line-length = 88
+src = ["src"]
+
+[tool.ruff.lint]
+select = [
+    "E", # pycodestyle errors
+    "F", # pyflakes
+    "W", # pycodestyle warnings
+    "I", # isort
+]
+ignore = [
+    "E501", # line too long (handled by formatter)
+]
+
+[tool.mypy]
+python_version = "3.9"
+check_untyped_defs = true
+disallow_untyped_defs = true
+warn_unused_configs = true
+mypy_path = "src"
+
+[[tool.mypy.overrides]]
+module = [
+    "numpy.*",
+    "pandas.*",
+    "polars.*",
+    "ruamel.*",
+    "tomli.*",
+    "tomli_w.*",
+    "msgpack.*",
+    "cbor2.*",
+    "bson.*",
+]
+ignore_missing_imports = true

--- a/src/lodum/__init__.py
+++ b/src/lodum/__init__.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 __version__ = "0.1.0"
 
+from . import bson, cbor, json, msgpack, pickle, toml, yaml
 from .core import lodum
 from .field import field
-from . import json, yaml, pickle, toml, msgpack, cbor, bson
 
 __all__ = [
     "lodum",

--- a/src/lodum/bson.py
+++ b/src/lodum/bson.py
@@ -7,9 +7,9 @@ except ImportError:
     bson = None  # type: ignore
 from typing import Any, Iterator, Type, TypeVar
 
-from .core import Loader, BaseDumper, BaseLoader
+from .core import BaseDumper, BaseLoader, Loader
 from .exception import DeserializationError
-from .internal import dump, load, DEFAULT_MAX_SIZE
+from .internal import DEFAULT_MAX_SIZE, dump, load
 
 T = TypeVar("T")
 

--- a/src/lodum/cbor.py
+++ b/src/lodum/cbor.py
@@ -7,9 +7,9 @@ except ImportError:
     cbor2 = None  # type: ignore
 from typing import Any, Iterator, Type, TypeVar
 
-from .core import Loader, BaseDumper, BaseLoader
+from .core import BaseDumper, BaseLoader, Loader
 from .exception import DeserializationError
-from .internal import dump, load, DEFAULT_MAX_SIZE
+from .internal import DEFAULT_MAX_SIZE, dump, load
 
 T = TypeVar("T")
 

--- a/src/lodum/core.py
+++ b/src/lodum/core.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2025-present Michael R. Bernstein <zopemaven@gmail.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-import inspect
 import functools
-from typing import Any, Dict, List, Protocol, Type, Iterator, TypeVar
+import inspect
+from typing import Any, Dict, Iterator, List, Protocol, Type, TypeVar
 
-from .field import Field, _MISSING
+from .field import _MISSING, Field
 
 T = TypeVar("T", bound=Type[Any])
 

--- a/src/lodum/internal.py
+++ b/src/lodum/internal.py
@@ -1,25 +1,25 @@
-import inspect
+import array
+import collections
 import datetime
 import enum
-import uuid
-import collections
-import array
+import inspect
 import threading
+import uuid
 from decimal import Decimal
 from pathlib import Path
 from typing import (
     Any,
     Callable,
     Dict,
+    ForwardRef,
     List,
     Optional,
     Type,
     TypeVar,
     Union,
-    get_origin,
-    get_args,
     cast,
-    ForwardRef,
+    get_args,
+    get_origin,
 )
 
 try:
@@ -37,7 +37,7 @@ try:
 except ImportError:
     pl = None  # type: ignore
 
-from .core import Loader, Dumper
+from .core import Dumper, Loader
 from .exception import DeserializationError, SerializationError
 from .field import Field
 

--- a/src/lodum/json.py
+++ b/src/lodum/json.py
@@ -4,9 +4,9 @@
 import json
 from typing import Any, Dict, Iterator, Type, TypeVar
 
-from .core import Loader, BaseDumper, BaseLoader
+from .core import BaseDumper, BaseLoader, Loader
 from .exception import DeserializationError
-from .internal import dump, load, generate_schema, DEFAULT_MAX_SIZE
+from .internal import DEFAULT_MAX_SIZE, dump, generate_schema, load
 
 T = TypeVar("T")
 

--- a/src/lodum/msgpack.py
+++ b/src/lodum/msgpack.py
@@ -7,9 +7,9 @@ except ImportError:
     msgpack = None  # type: ignore
 from typing import Any, Iterator, Type, TypeVar
 
-from .core import Loader, BaseDumper, BaseLoader
+from .core import BaseDumper, BaseLoader, Loader
 from .exception import DeserializationError
-from .internal import dump, load, DEFAULT_MAX_SIZE
+from .internal import DEFAULT_MAX_SIZE, dump, load
 
 T = TypeVar("T")
 

--- a/src/lodum/pickle.py
+++ b/src/lodum/pickle.py
@@ -1,14 +1,15 @@
 # SPDX-FileCopyrightText: 2025-present Michael R. Bernstein <zopemaven@gmail.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-import pickle
 import builtins
 import io
+import pickle
 from typing import Any, Type, TypeVar
 
 from .core import Dumper
-from .internal import dump as validate_lodum_structure, DEFAULT_MAX_SIZE
 from .exception import DeserializationError
+from .internal import DEFAULT_MAX_SIZE
+from .internal import dump as validate_lodum_structure
 
 T = TypeVar("T")
 

--- a/src/lodum/toml.py
+++ b/src/lodum/toml.py
@@ -15,9 +15,9 @@ except ImportError:
     tomli_w = None  # type: ignore
 from typing import Any, Iterator, Type, TypeVar
 
-from .core import Loader, BaseDumper, BaseLoader
+from .core import BaseDumper, BaseLoader, Loader
 from .exception import DeserializationError
-from .internal import dump, load, DEFAULT_MAX_SIZE
+from .internal import DEFAULT_MAX_SIZE, dump, load
 
 T = TypeVar("T")
 

--- a/src/lodum/yaml.py
+++ b/src/lodum/yaml.py
@@ -12,9 +12,9 @@ except ImportError:
     YAML = None  # type: ignore
     yaml_available = False
 
-from .core import Loader, BaseDumper
-from .internal import dump, load, DEFAULT_MAX_SIZE
+from .core import BaseDumper, Loader
 from .exception import DeserializationError
+from .internal import DEFAULT_MAX_SIZE, dump, load
 
 T = TypeVar("T")
 yaml: Any = None


### PR DESCRIPTION
- Added [tool.ruff], [tool.ruff.lint], and [tool.mypy] sections to pyproject.toml.
- Configured Ruff with E, F, W, and I (isort) rules.
- Configured Mypy with strict type checking settings and ignored missing imports for optional dependencies.
- Reorganized imports across the codebase to comply with the new isort rule.
- Verified that both tools pass with the new configurations and all tests pass.