### PR TITLE
Optimize ForwardRef resolution using name-to-type cache

### DIFF
--- a/src/lodum/internal.py
+++ b/src/lodum/internal.py
@@ -68,6 +68,7 @@ def _sanitize_name(name: str) -> str:
 
 _DUMP_HANDLER_CACHE: Dict[Type[Any], DumpHandler] = {}
 _LOAD_HANDLER_CACHE: Dict[Type[Any], LoadHandler] = {}
+_NAME_TO_TYPE_CACHE: Dict[str, Type[Any]] = {}
 _CACHE_LOCK = threading.Lock()
 
 
@@ -310,6 +311,8 @@ def _get_dump_handler(t: Type[Any]) -> DumpHandler:
         t = ForwardRef(t)
 
     with _CACHE_LOCK:
+        if inspect.isclass(t) and not isinstance(t, ForwardRef):
+            _NAME_TO_TYPE_CACHE[t.__name__] = t
         if t in _DUMP_HANDLER_CACHE:
             return _DUMP_HANDLER_CACHE[t]
 
@@ -498,6 +501,8 @@ def _get_load_handler(t: Type[Any]) -> LoadHandler:
         t = ForwardRef(t)
 
     with _CACHE_LOCK:
+        if inspect.isclass(t) and not isinstance(t, ForwardRef):
+            _NAME_TO_TYPE_CACHE[t.__name__] = t
         if t in _LOAD_HANDLER_CACHE:
             return _LOAD_HANDLER_CACHE[t]
 
@@ -505,13 +510,11 @@ def _get_load_handler(t: Type[Any]) -> LoadHandler:
         return _load_any
     if isinstance(t, ForwardRef):
         ref_name = t.__forward_arg__
-        for cls in LOAD_DISPATCH:
-            if inspect.isclass(cls) and cls.__name__ == ref_name:
-                return _get_load_handler(cls)
+        resolved_type = None
         with _CACHE_LOCK:
-            for cls in _LOAD_HANDLER_CACHE:
-                if inspect.isclass(cls) and cls.__name__ == ref_name:
-                    return _LOAD_HANDLER_CACHE[cls]
+            resolved_type = _NAME_TO_TYPE_CACHE.get(ref_name)
+        if resolved_type:
+            return _get_load_handler(resolved_type)
         raise DeserializationError(f"Cannot resolve ForwardRef {ref_name!r}")
 
     origin = get_origin(t) or t
@@ -1155,3 +1158,8 @@ if pd is not None:
 if pl is not None:
     LOAD_DISPATCH[pl.DataFrame] = _load_polars_dataframe
     LOAD_DISPATCH[pl.Series] = _load_polars_series
+
+# Initialize name-to-type cache with basic types
+for _cls in LOAD_DISPATCH:
+    if inspect.isclass(_cls):
+        _NAME_TO_TYPE_CACHE[_cls.__name__] = _cls

--- a/tests/test_forward_ref_optimization.py
+++ b/tests/test_forward_ref_optimization.py
@@ -1,0 +1,43 @@
+from lodum import lodum, json
+from typing import Optional
+import pytest
+
+@lodum
+class Node:
+    def __init__(self, value: int, next: Optional["Node"] = None):
+        self.value = value
+        self.next = next
+
+@lodum
+class A:
+    def __init__(self, b: Optional["B"] = None):
+        self.b = b
+
+@lodum
+class B:
+    def __init__(self, a: Optional["A"] = None):
+        self.a = a
+
+def test_recursive_forward_ref():
+    data = '{"value": 1, "next": {"value": 2, "next": null}}'
+    node = json.loads(Node, data)
+    assert node.value == 1
+    assert node.next.value == 2
+    assert node.next.next is None
+
+    # Round trip
+    dumped = json.dumps(node)
+    assert json.loads(Node, dumped).value == 1
+
+def test_mutual_recursive_forward_ref():
+    _ = json.dumps(B(a=None)) # Register B
+
+    data = '{"b": {"a": null}}'
+    a = json.loads(A, data)
+    assert a.b.a is None
+    assert isinstance(a.b, B)
+
+if __name__ == "__main__":
+    test_recursive_forward_ref()
+    test_mutual_recursive_forward_ref()
+    print("All tests passed!")


### PR DESCRIPTION
Introduced _NAME_TO_TYPE_CACHE in internal.py to achieve O(1) lookup for ForwardRef resolution. Updated _get_load_handler and _get_dump_handler to populate the cache and modified ForwardRef resolution to use it. Added comprehensive tests for recursive and mutual-recursive types. Ensured thread safety and avoided deadlocks by carefully managing lock acquisitions.