### PR TITLE
Organize benchmark results and improve statistical reliability.

### DIFF
--- a/BENCHMARK_RESULTS.md
+++ b/BENCHMARK_RESULTS.md
@@ -1,71 +1,10 @@
-# Lodum Performance Benchmarks
+# Lodum Benchmark History
 
-Iterations: 2000
+This file tracks the history of benchmark runs for Lodum. Each run is organized into a nested folder named by the date and description of the run.
 
-Python version: 3.12.12 (main, Nov  7 2025, 00:07:10) [GCC 13.3.0]
+| Run Date | Description | Path |
+| :--- | :--- | :--- |
+| 2025-01-19 | Initial Baseline | [benchmarks/results/2025-01-19_baseline/BENCHMARK_RESULTS.md](benchmarks/results/2025-01-19_baseline/BENCHMARK_RESULTS.md) |
+| 2025-01-19 | Statistical & Optimized | [benchmarks/results/2025-01-19_statistical_optimized/BENCHMARK_RESULTS.md](benchmarks/results/2025-01-19_statistical_optimized/BENCHMARK_RESULTS.md) |
 
-### JSON Serialization (Object -> JSON)
-| Library | Simple (us) | Complex (us) | Nested (us) |
-| :--- | ---: | ---: | ---: |
-| Lodum | 8.24 | 31.47 | 33.58 |
-| Pydantic (v2) | 1.90 | 2.76 | 5.22 |
-| Marshmallow | 11.10 | 24.55 | 63.11 |
-| Native json (dict) | 3.85 | 5.99 | 9.67 |
-| orjson (dict) | 0.33 | 0.57 | 0.86 |
-
-### JSON Deserialization (JSON -> Object)
-| Library | Simple (us) | Complex (us) | Nested (us) |
-| :--- | ---: | ---: | ---: |
-| Lodum | 22.06 | 45.39 | 131.68 |
-| Pydantic (v2) | 2.88 | 4.00 | 10.58 |
-| Marshmallow | 27.64 | 65.16 | 196.23 |
-| Native json (dict) | 2.96 | 4.75 | 8.41 |
-| orjson (dict) | 0.60 | 1.29 | 2.66 |
-
-### MsgPack Serialization
-| Library | Simple (us) | Complex (us) | Nested (us) |
-| :--- | ---: | ---: | ---: |
-| Lodum | 4.89 | 25.56 | 25.97 |
-| Native msgpack (dict) | 0.95 | 1.67 | 3.33 |
-
-### MsgPack Deserialization
-| Library | Simple (us) | Complex (us) | Nested (us) |
-| :--- | ---: | ---: | ---: |
-| Lodum | 17.84 | 38.71 | 124.40 |
-| Native msgpack (dict) | 0.84 | 2.02 | 5.00 |
-
-### CBOR Serialization
-| Library | Simple (us) | Complex (us) | Nested (us) |
-| :--- | ---: | ---: | ---: |
-| Lodum | 12.51 | 37.00 | 41.75 |
-| Native cbor2 (dict) | 8.44 | 11.87 | 17.44 |
-
-### CBOR Deserialization
-| Library | Simple (us) | Complex (us) | Nested (us) |
-| :--- | ---: | ---: | ---: |
-| Lodum | 22.41 | 44.90 | 132.87 |
-| Native cbor2 (dict) | 3.16 | 4.82 | 8.52 |
-
-### YAML Serialization
-| Library | Simple (us) | Complex (us) | Nested (us) |
-| :--- | ---: | ---: | ---: |
-| Lodum | 496.58 | 2403.27 | 3204.83 |
-| ruamel.yaml (dict) | 724.30 | 1858.29 | 976.29 |
-
-### YAML Deserialization
-| Library | Simple (us) | Complex (us) | Nested (us) |
-| :--- | ---: | ---: | ---: |
-| Lodum | 538.71 | 1450.11 | 1488.50 |
-| ruamel.yaml (dict) | 470.63 | 1470.87 | 1184.72 |
-
-### Pickle Serialization
-| Library | Simple (us) | Complex (us) | Nested (us) |
-| :--- | ---: | ---: | ---: |
-| Lodum (Safe) | 8.01 | 32.32 | 38.42 |
-| Native pickle | 3.88 | 4.70 | 14.65 |
-
-### Pickle Deserialization
-| Library | Simple (us) | Complex (us) | Nested (us) |
-| :--- | ---: | ---: | ---: |
-| Lodum (Safe) | 7.22 | 9.17 | 15.54 |
-| Native pickle | 3.62 | 5.28 | 11.11 |
+For the latest performance analysis and summary, see [PERFORMANCE.md](PERFORMANCE.md).

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -9,29 +9,29 @@ The following benchmarks were run on Python 3.12.12. Results are in microseconds
 ### JSON Serialization (Object -> JSON)
 | Library | Simple (us) | Complex (us) | Nested (us) |
 | :--- | ---: | ---: | ---: |
-| Lodum | 8.24 | 31.47 | 33.58 |
-| Pydantic (v2) | 1.90 | 2.76 | 5.22 |
-| Marshmallow | 11.10 | 24.55 | 63.11 |
-| Native json (dict) | 3.85 | 5.99 | 9.67 |
+| Lodum | 6.55 ± 0.27 | 25.64 ± 0.21 | 26.86 ± 0.29 |
+| Pydantic (v2) | 1.97 ± 0.03 | 2.74 ± 0.04 | 5.27 ± 0.03 |
+| Marshmallow | 11.58 ± 0.06 | 27.72 ± 5.25 | 81.42 ± 3.37 |
+| Native json (dict) | 4.84 ± 0.79 | 7.81 ± 1.28 | 15.44 ± 2.46 |
 
 ### JSON Deserialization (JSON -> Object)
 | Library | Simple (us) | Complex (us) | Nested (us) |
 | :--- | ---: | ---: | ---: |
-| Lodum | 22.06 | 45.39 | 131.68 |
-| Pydantic (v2) | 2.88 | 4.00 | 10.58 |
-| Marshmallow | 27.64 | 65.16 | 196.23 |
-| Native json (dict) | 2.96 | 4.75 | 8.41 |
+| Lodum | 21.09 ± 1.21 | 40.50 ± 1.18 | 125.10 ± 2.11 |
+| Pydantic (v2) | 2.82 ± 0.82 | 3.98 ± 0.09 | 10.34 ± 0.07 |
+| Marshmallow | 27.67 ± 0.34 | 64.40 ± 0.37 | 193.85 ± 1.76 |
+| Native json (dict) | 2.90 ± 0.02 | 4.68 ± 0.05 | 8.16 ± 0.02 |
 
 ### Binary Formats (Lodum vs Native)
 
 | Format | Operation | Simple (us) | Complex (us) | Nested (us) |
 | :--- | :--- | ---: | ---: | ---: |
-| **MsgPack** | Serialization | 4.89 | 25.56 | 25.97 |
-| | Deserialization | 17.84 | 38.71 | 124.40 |
-| **CBOR** | Serialization | 12.51 | 37.00 | 41.75 |
-| | Deserialization | 22.41 | 44.90 | 132.87 |
-| **Pickle** | Serialization | 8.01 | 32.32 | 38.42 |
-| | Deserialization | 7.22 | 9.17 | 15.54 |
+| **MsgPack** | Serialization | 3.90 ± 0.04 | 19.75 ± 0.31 | 20.10 ± 0.12 |
+| | Deserialization | 16.83 ± 0.18 | 35.29 ± 0.38 | 116.42 ± 0.52 |
+| **CBOR** | Serialization | 11.73 ± 0.16 | 35.63 ± 3.14 | 41.52 ± 5.27 |
+| | Deserialization | 20.30 ± 0.24 | 59.80 ± 21.04 | 238.30 ± 18.22 |
+| **Pickle** | Serialization | 7.10 ± 0.06 | 22.72 ± 0.07 | 32.51 ± 1.14 |
+| | Deserialization | 6.99 ± 0.03 | 9.05 ± 0.06 | 15.18 ± 0.06 |
 
 ## Analysis
 

--- a/benchmarks/results/2025-01-19_baseline/BENCHMARK_RESULTS.md
+++ b/benchmarks/results/2025-01-19_baseline/BENCHMARK_RESULTS.md
@@ -1,0 +1,71 @@
+# Lodum Performance Benchmarks
+
+Iterations: 2000
+
+Python version: 3.12.12 (main, Nov  7 2025, 00:07:10) [GCC 13.3.0]
+
+### JSON Serialization (Object -> JSON)
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 8.24 | 31.47 | 33.58 |
+| Pydantic (v2) | 1.90 | 2.76 | 5.22 |
+| Marshmallow | 11.10 | 24.55 | 63.11 |
+| Native json (dict) | 3.85 | 5.99 | 9.67 |
+| orjson (dict) | 0.33 | 0.57 | 0.86 |
+
+### JSON Deserialization (JSON -> Object)
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 22.06 | 45.39 | 131.68 |
+| Pydantic (v2) | 2.88 | 4.00 | 10.58 |
+| Marshmallow | 27.64 | 65.16 | 196.23 |
+| Native json (dict) | 2.96 | 4.75 | 8.41 |
+| orjson (dict) | 0.60 | 1.29 | 2.66 |
+
+### MsgPack Serialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 4.89 | 25.56 | 25.97 |
+| Native msgpack (dict) | 0.95 | 1.67 | 3.33 |
+
+### MsgPack Deserialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 17.84 | 38.71 | 124.40 |
+| Native msgpack (dict) | 0.84 | 2.02 | 5.00 |
+
+### CBOR Serialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 12.51 | 37.00 | 41.75 |
+| Native cbor2 (dict) | 8.44 | 11.87 | 17.44 |
+
+### CBOR Deserialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 22.41 | 44.90 | 132.87 |
+| Native cbor2 (dict) | 3.16 | 4.82 | 8.52 |
+
+### YAML Serialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 496.58 | 2403.27 | 3204.83 |
+| ruamel.yaml (dict) | 724.30 | 1858.29 | 976.29 |
+
+### YAML Deserialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 538.71 | 1450.11 | 1488.50 |
+| ruamel.yaml (dict) | 470.63 | 1470.87 | 1184.72 |
+
+### Pickle Serialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum (Safe) | 8.01 | 32.32 | 38.42 |
+| Native pickle | 3.88 | 4.70 | 14.65 |
+
+### Pickle Deserialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum (Safe) | 7.22 | 9.17 | 15.54 |
+| Native pickle | 3.62 | 5.28 | 11.11 |

--- a/benchmarks/results/2025-01-19_statistical_optimized/BENCHMARK_RESULTS.md
+++ b/benchmarks/results/2025-01-19_statistical_optimized/BENCHMARK_RESULTS.md
@@ -1,0 +1,71 @@
+# Lodum Performance Benchmarks
+
+Iterations: 2000
+
+Python version: 3.12.12 (main, Nov  7 2025, 00:07:10) [GCC 13.3.0]
+
+### JSON Serialization (Object -> JSON)
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 6.55 ± 0.27 | 25.64 ± 0.21 | 26.86 ± 0.29 |
+| Pydantic (v2) | 1.97 ± 0.03 | 2.74 ± 0.04 | 5.27 ± 0.03 |
+| Marshmallow | 11.58 ± 0.06 | 27.72 ± 5.25 | 81.42 ± 3.37 |
+| Native json (dict) | 4.84 ± 0.79 | 7.81 ± 1.28 | 15.44 ± 2.46 |
+| orjson (dict) | 0.50 ± 0.04 | 0.91 ± 0.04 | 1.15 ± 0.07 |
+
+### JSON Deserialization (JSON -> Object)
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 21.09 ± 1.21 | 40.50 ± 1.18 | 125.10 ± 2.11 |
+| Pydantic (v2) | 2.82 ± 0.82 | 3.98 ± 0.09 | 10.34 ± 0.07 |
+| Marshmallow | 27.67 ± 0.34 | 64.40 ± 0.37 | 193.85 ± 1.76 |
+| Native json (dict) | 2.90 ± 0.02 | 4.68 ± 0.05 | 8.16 ± 0.02 |
+| orjson (dict) | 0.58 ± 0.01 | 1.40 ± 0.05 | 2.67 ± 0.01 |
+
+### MsgPack Serialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 3.90 ± 0.04 | 19.75 ± 0.31 | 20.10 ± 0.12 |
+| Native msgpack (dict) | 0.93 ± 0.01 | 1.57 ± 0.02 | 3.14 ± 0.03 |
+
+### MsgPack Deserialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 16.83 ± 0.18 | 35.29 ± 0.38 | 116.42 ± 0.52 |
+| Native msgpack (dict) | 0.84 ± 0.02 | 1.98 ± 0.01 | 4.99 ± 0.04 |
+
+### CBOR Serialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 11.73 ± 0.16 | 35.63 ± 3.14 | 41.52 ± 5.27 |
+| Native cbor2 (dict) | 11.64 ± 0.12 | 16.66 ± 0.68 | 17.40 ± 0.52 |
+
+### CBOR Deserialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 20.30 ± 0.24 | 59.80 ± 21.04 | 238.30 ± 18.22 |
+| Native cbor2 (dict) | 4.92 ± 0.16 | 7.73 ± 0.24 | 15.42 ± 0.73 |
+
+### YAML Serialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 675.55 ± 202.43 | 1190.75 ± 33.93 | 2773.75 ± 32.08 |
+| ruamel.yaml (dict) | 479.82 ± 2.26 | 1098.12 ± 11.04 | 918.68 ± 4.44 |
+
+### YAML Deserialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum | 516.77 ± 4.58 | 1374.45 ± 10.70 | 1459.11 ± 78.88 |
+| ruamel.yaml (dict) | 491.33 ± 19.55 | 1307.06 ± 45.36 | 1400.55 ± 282.26 |
+
+### Pickle Serialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum (Safe) | 7.10 ± 0.06 | 22.72 ± 0.07 | 32.51 ± 1.14 |
+| Native pickle | 4.38 ± 0.22 | 4.72 ± 0.08 | 15.02 ± 0.09 |
+
+### Pickle Deserialization
+| Library | Simple (us) | Complex (us) | Nested (us) |
+| :--- | ---: | ---: | ---: |
+| Lodum (Safe) | 6.99 ± 0.03 | 9.05 ± 0.06 | 15.18 ± 0.06 |
+| Native pickle | 3.58 ± 0.02 | 5.30 ± 0.04 | 11.11 ± 0.03 |

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -2,6 +2,7 @@ import timeit
 import json
 import os
 import sys
+import statistics
 
 # Optional dependencies
 try:
@@ -124,8 +125,13 @@ def bench(func):
         return None
     timer = timeit.Timer(func)
     try:
-        t = timer.timeit(number=ITERATIONS)
-        return t / ITERATIONS * 1e6 # return in microseconds
+        # Run 5 trials to get a measure of variance
+        times = timer.repeat(repeat=5, number=ITERATIONS)
+        us_per_op = [(t / ITERATIONS) * 1e6 for t in times]
+        return {
+            "mean": statistics.mean(us_per_op),
+            "stdev": statistics.stdev(us_per_op)
+        }
     except Exception as e:
         # print(f"Error: {e}")
         return None
@@ -136,17 +142,19 @@ def run_group(group_name: str, benchmarks: Dict[str, Dict[str, Optional[Callable
     print("| :--- | ---: | ---: | ---: |")
 
     for lib_name, funcs in benchmarks.items():
-        simple_time = bench(funcs.get("simple"))
-        complex_time = bench(funcs.get("complex"))
-        nested_time = bench(funcs.get("nested"))
+        simple_res = bench(funcs.get("simple"))
+        complex_res = bench(funcs.get("complex"))
+        nested_res = bench(funcs.get("nested"))
 
-        if simple_time is None and complex_time is None and nested_time is None:
+        if simple_res is None and complex_res is None and nested_res is None:
             continue
 
-        def fmt(t):
-            return f"{t:.2f}" if t is not None else "N/A"
+        def fmt(res):
+            if res is None:
+                return "N/A"
+            return f"{res['mean']:.2f} ± {res['stdev']:.2f}"
 
-        print(f"| {lib_name} | {fmt(simple_time)} | {fmt(complex_time)} | {fmt(nested_time)} |")
+        print(f"| {lib_name} | {fmt(simple_res)} | {fmt(complex_res)} | {fmt(nested_res)} |")
     print()
 
 def run_all():

--- a/src/lodum/internal.py
+++ b/src/lodum/internal.py
@@ -307,14 +307,21 @@ def _compile_dump_handler(cls: Type[Any]) -> DumpHandler:
 
 
 def _get_dump_handler(t: Type[Any]) -> DumpHandler:
+    # Hot path
+    handler = _DUMP_HANDLER_CACHE.get(t)
+    if handler is not None:
+        return handler
+
     if isinstance(t, str):
         t = ForwardRef(t)
 
     with _CACHE_LOCK:
-        if inspect.isclass(t) and not isinstance(t, ForwardRef):
-            _NAME_TO_TYPE_CACHE[t.__name__] = t
+        # Check again under lock
         if t in _DUMP_HANDLER_CACHE:
             return _DUMP_HANDLER_CACHE[t]
+
+        if inspect.isclass(t) and not isinstance(t, ForwardRef):
+            _NAME_TO_TYPE_CACHE[t.__name__] = t
 
     if t in DUMP_DISPATCH:
         handler = DUMP_DISPATCH[t]
@@ -497,14 +504,21 @@ def _compile_load_handler(cls: Type[Any]) -> LoadHandler:
 
 
 def _get_load_handler(t: Type[Any]) -> LoadHandler:
+    # Hot path
+    handler = _LOAD_HANDLER_CACHE.get(t)
+    if handler is not None:
+        return handler
+
     if isinstance(t, str):
         t = ForwardRef(t)
 
     with _CACHE_LOCK:
-        if inspect.isclass(t) and not isinstance(t, ForwardRef):
-            _NAME_TO_TYPE_CACHE[t.__name__] = t
+        # Check again under lock
         if t in _LOAD_HANDLER_CACHE:
             return _LOAD_HANDLER_CACHE[t]
+
+        if inspect.isclass(t) and not isinstance(t, ForwardRef):
+            _NAME_TO_TYPE_CACHE[t.__name__] = t
 
     if isinstance(t, TypeVar):
         return _load_any


### PR DESCRIPTION
- Modified `benchmarks/run.py` to use `timer.repeat(repeat=5)` and report performance as `mean ± standard deviation`.
- Created `benchmarks/results/` directory to store historical benchmark data.
- Preserved original baseline results in `benchmarks/results/2025-01-19_baseline/`.
- Saved new statistical results in `benchmarks/results/2025-01-19_statistical_optimized/`.
- Updated root `BENCHMARK_RESULTS.md` to serve as a table of contents for benchmark history.
- Optimized internal handler lookup paths in `src/lodum/internal.py` for better performance.
- Updated `PERFORMANCE.md` with new statistical metrics.