### PR TITLE
Add Ergonomic Dict API and expand collections support

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,44 @@ print(json.dumps(schema, indent=2))
 # }
 ```
 
+## Converting to/from Dictionaries
+
+While `lodum` is primarily used for external wire formats, it also provides ergonomic helpers for converting objects to and from plain Python primitives (dictionaries and lists) without any string encoding.
+
+### `lodum.asdict(obj)`
+Recursively converts a lodum-enabled object into standard Python primitives. This is a "Deep Normalization" that handles renaming, skipping fields, and converting complex types like Enums or Datetimes into plain values.
+
+```python
+import lodum
+
+@lodum
+class User:
+    def __init__(self, user_id: int = lodum.field(rename="id"), name: str = ""):
+        self.user_id = user_id
+        self.name = name
+
+user = User(user_id=1, name="Alex")
+data = lodum.asdict(user)
+print(data)
+# Output: {"id": 1, "name": "Alex"}
+```
+
+### `lodum.fromdict(cls, data)`
+Hydrates a lodum-enabled class from a dictionary. Unlike standard dictionary assignment, this performs full type validation and automatically instantiates nested objects.
+
+```python
+new_user = lodum.fromdict(User, {"id": 2, "name": "Sam"})
+```
+
+### Supported Collection Wrappers
+`lodum` automatically normalizes and hydrates various standard library collection wrappers, converting them to/from standard `list` and `dict` during serialization:
+- `collections.deque`
+- `collections.UserList`
+- `collections.UserDict`
+- `collections.Counter`
+- `collections.defaultdict`
+- `collections.OrderedDict`
+
 ## Performance
 
 `lodum` is designed for high performance. When you first use a `@lodum`-enabled class, the library analyzes its structure and generates specialized Python bytecode for serialization and deserialization using an internal Abstract Syntax Tree (AST) compiler. 

--- a/src/lodum/__init__.py
+++ b/src/lodum/__init__.py
@@ -7,6 +7,32 @@ from .core import lodum
 from .field import field
 from .internal import generate_schema as schema
 from . import json, yaml, pickle, toml, msgpack, cbor, bson
+from typing import Any, Type, TypeVar
+
+T = TypeVar("T")
+
+
+def asdict(obj: Any) -> Any:
+    """
+    Recursively converts a lodum-enabled object into plain Python primitives (dict, list, etc.).
+    This handles renaming, skipping fields, and converting enums/datetimes to values.
+    """
+    from .internal import dump
+    from .core import BaseDumper
+
+    return dump(obj, BaseDumper())
+
+
+def fromdict(cls: Type[T], data: Any) -> T:
+    """
+    Hydrates a lodum-enabled class from a dictionary or other plain Python primitives.
+    This performs full type validation and nested object instantiation.
+    """
+    from .internal import load
+    from .core import BaseLoader
+
+    return load(cls, BaseLoader(data))
+
 
 # Register extensions if available
 try:
@@ -34,6 +60,8 @@ __all__ = [
     "lodum",
     "field",
     "schema",
+    "asdict",
+    "fromdict",
     "json",
     "yaml",
     "pickle",

--- a/src/lodum/internal.py
+++ b/src/lodum/internal.py
@@ -506,6 +506,15 @@ def _register_builtin_handlers(ctx: Context) -> None:
 
     # Collections
     ctx.registry.register(
+        collections.deque, TypeHandler(_dump_sequence, _load_list, _schema_list)
+    )
+    ctx.registry.register(
+        collections.UserList, TypeHandler(_dump_sequence, _load_list, _schema_list)
+    )
+    ctx.registry.register(
+        collections.UserDict, TypeHandler(_dump_dict, _load_dict, _schema_dict)
+    )
+    ctx.registry.register(
         collections.defaultdict,
         TypeHandler(_dump_dict, _load_defaultdict, _schema_dict),
     )

--- a/tests/test_dict_api.py
+++ b/tests/test_dict_api.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2025-present Michael R. Bernstein <zopemaven@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import collections
+from dataclasses import dataclass
+from typing import List, Optional
+import lodum
+
+
+@lodum.lodum
+class Child:
+    def __init__(self, name: str):
+        self.name = name
+
+
+@lodum.lodum
+class Parent:
+    def __init__(
+        self, id: int = lodum.field(rename="pk"), children: List[Child] = lodum.field(default_factory=list)
+    ):
+        self.id = id
+        self.children = children
+
+
+def test_asdict_normalization():
+    # Test normalization of UserList and UserDict subclasses
+    class MyList(collections.UserList):
+        pass
+
+    class MyDict(collections.UserDict):
+        pass
+
+    data = MyList([Child(name="A"), Child(name="B")])
+    res = lodum.asdict(data)
+
+    # Result should be a plain list of plain dicts
+    assert isinstance(res, list)
+    assert res == [{"name": "A"}, {"name": "B"}]
+    assert type(res) is list
+
+
+def test_asdict_deep_parent():
+    p = Parent(id=1, children=[Child(name="C1")])
+    res = lodum.asdict(p)
+
+    assert res == {"pk": 1, "children": [{"name": "C1"}]}
+    assert type(res) is dict
+
+
+def test_fromdict_hydration():
+    data = {"pk": 10, "children": [{"name": "C1"}, {"name": "C2"}]}
+    obj = lodum.fromdict(Parent, data)
+
+    assert isinstance(obj, Parent)
+    assert obj.id == 10
+    assert len(obj.children) == 2
+    assert isinstance(obj.children[0], Child)
+    assert obj.children[0].name == "C1"
+
+
+def test_fromdict_validation_error():
+    data = {"pk": "not-an-int"}
+    with pytest.raises(lodum.exception.DeserializationError, match="Expected int"):
+        lodum.fromdict(Parent, data)
+
+
+def test_deque_normalization():
+    dq = collections.deque([1, 2, 3])
+    res = lodum.asdict(dq)
+    assert res == [1, 2, 3]
+    assert type(res) is list
+
+
+def test_userdict_normalization():
+    class MyDict(collections.UserDict):
+        pass
+
+    d = MyDict({"a": 1, "b": 2})
+    res = lodum.asdict(d)
+    assert res == {"a": 1, "b": 2}
+    assert type(res) is dict


### PR DESCRIPTION
This PR adds lodum.asdict() and lodum.fromdict() for deep object-to-dict normalization and hydration. It also adds native support for UserList, UserDict, and deque.