### PR TITLE
docs: Document task tracking process and labels (Closes #39)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,6 +35,25 @@ There are many ways to contribute, from writing tutorials or blog posts, improvi
 
 - Open a new issue and provide a clear description of the enhancement you'd like to see, why it's useful, and if possible, a suggestion for how it could be implemented.
 
+### Tracking Project Progress
+
+`lodum` uses GitHub Issues and a Project Board to manage its development roadmap, features, and bugs. This system helps ensure clarity, accountability, and efficient progress.
+
+**Issue Labels:**
+We categorize issues using `type:` and `status:` labels:
+*   `type: epic`: Major roadmap items or significant features.
+*   `type: story`: Smaller, actionable tasks contributing to an epic.
+*   `type: bug`: Issues identifying defects.
+*   `type: chore`: Maintenance tasks, refactoring, or non-feature work.
+*   `status: backlog`: Tasks awaiting prioritization.
+*   `status: ready`: Tasks ready to be picked up by a developer.
+*   `status: in-progress`: Tasks actively being worked on.
+*   `status: in-review`: Tasks with an open Pull Request awaiting review.
+*   `status: done`: Completed tasks (typically auto-closed by PR merges).
+
+**Project Board:**
+You can view the overall project status and progress on our [GitHub Project Board](https://github.com/users/webmaven/projects/1). This Kanban board visualizes the flow of tasks through various stages.
+
 ### Pull Requests
 
 - Open a new GitHub pull request with the patch.


### PR DESCRIPTION
This PR addresses Issue #39: "Implement Formal Task Tracking for Roadmap Items".

A new section titled "Tracking Project Progress" has been added to `docs/CONTRIBUTING.md`. This section outlines the newly established task tracking process for `lodum`, including:
- Definition of `type:` and `status:` GitHub issue labels.
- Introduction of the GitHub Project Board for visualizing task flow.
- Details on how issues are used to manage the development roadmap, features, and bugs.

This commit formally establishes the task tracking process as approved.