### PR TITLE
docs: Enforce linking PRs to issues in CONTRIBUTING.md (Closes #40)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -58,6 +58,7 @@ You can view the overall project status and progress on our [GitHub Project Boar
 
 - Open a new GitHub pull request with the patch.
 - Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+- **Link to Issues**: All Pull Requests must be explicitly linked to one or more GitHub Issues they resolve or implement. Use closing keywords (e.g., `Closes #<issue_number>`, `Fixes #<issue_number>`, `Resolves #<issue_number>`) in your PR description. This automatically closes the associated issue upon merging the PR and ensures proper traceability.
 - Before submitting, please ensure that your code follows the existing style of the project, and that all tests pass.
 
 ### Submitting Implementation Plans
@@ -127,7 +128,7 @@ Before submitting a pull request, please run the following checks to ensure code
 ## Styleguides
 
 - We use [Ruff](https://github.com/astral-sh/ruff) for code formatting and linting. Please run it on your code before submitting a pull request.
-- We follow [PEP 8](https://www.python.org/dev/peps/pep-0008/) for all Python code.
+- We follow [PEP 8](https://www.python.org/dev/psps/pep-0008/) for all Python code.
 
 ## Core Development Guidelines
 


### PR DESCRIPTION
This PR addresses Issue #40: "Enforce Linking of Pull Requests to Specific Tasks/Issues".

New guidance has been added to the "Pull Requests" section of `docs/CONTRIBUTING.md`. This guidance requires contributors to explicitly link their Pull Requests to GitHub Issues using closing keywords (e.g., `Closes #<issue_number>`) in their PR description.

This policy ensures comprehensive traceability, improves the clarity and efficiency of code reviews, and leverages GitHub's automatic issue closing feature, as established by the task tracking process in Issue #39.
